### PR TITLE
feat: add Sifflet plugin with RunRule and ListRules tasks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,74 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build with Gradle
+      run: ./gradlew build
+
+    - name: Upload build reports
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: build-reports
+        path: |
+          build/reports/tests
+          build/reports/jacoco
+        retention-days: 14
+
+  release:
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build and publish
+      env:
+        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+        GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+        GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      run: |
+        echo "$GPG_PRIVATE_KEY" > private.key
+        gpg --batch --import private.key
+        ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository 

--- a/README.md
+++ b/README.md
@@ -74,3 +74,144 @@ Apache 2.0 © [Kestra Technologies](https://kestra.io)
 We release new versions every month. Give the [main repository](https://github.com/kestra-io/kestra) a star to stay up to date with the latest releases and get notified about future updates.
 
 ![Star the repo](https://kestra.io/star.gif)
+
+# Sifflet Plugin for Kestra
+
+This plugin provides integration with Sifflet's data quality platform, allowing you to run data quality rules from your Kestra workflows.
+
+## Installation
+
+Add the plugin to your Kestra installation by adding the following to your `kestra.yml`:
+
+```yaml
+plugins:
+  - io.kestra.plugin:sifflet:0.1.0
+```
+
+## Tasks
+
+### RunRule
+
+The `RunRule` task allows you to execute a Sifflet rule and wait for its completion.
+
+#### Example
+
+```yaml
+id: run-sifflet-rule
+type: io.kestra.plugin.sifflet.tasks.RunRule
+url: https://api.siffletdata.com
+apiKey: "{{ secret('SIFFLET_API_KEY') }}"
+ruleId: "rule-123"
+```
+
+#### Properties
+
+| Property        | Type    | Description                                    | Required | Default |
+|-----------------|---------|------------------------------------------------|----------|---------|
+| url             | string  | The base URL for Sifflet API                   | Yes      | -       |
+| apiKey          | string  | Your Sifflet API key                           | Yes      | -       |
+| ruleId          | string  | The ID of the rule to run                      | Yes      | -       |
+| pollingInterval | integer | Seconds between status checks                  | No       | 5       |
+| timeout         | integer | Maximum seconds to wait for completion         | No       | 3600    |
+
+#### Outputs
+
+| Property     | Type   | Description                    |
+|--------------|--------|--------------------------------|
+| executionId  | string | The ID of the rule execution   |
+| status       | string | The final status of execution  |
+
+### ListRules
+
+The `ListRules` task allows you to retrieve a list of rules from Sifflet.
+
+#### Example
+
+```yaml
+id: list-sifflet-rules
+type: io.kestra.plugin.sifflet.tasks.ListRules
+url: https://api.siffletdata.com
+apiKey: "{{ secret('SIFFLET_API_KEY') }}"
+pageSize: 100
+pageNumber: 1
+```
+
+#### Properties
+
+| Property   | Type    | Description                                    | Required | Default |
+|------------|---------|------------------------------------------------|----------|---------|
+| url        | string  | The base URL for Sifflet API                   | Yes      | -       |
+| apiKey     | string  | Your Sifflet API key                           | Yes      | -       |
+| pageSize   | integer | Number of rules to return per page             | No       | 100     |
+| pageNumber | integer | Page number to retrieve                        | No       | 1       |
+
+#### Outputs
+
+| Property    | Type                | Description                    |
+|-------------|---------------------|--------------------------------|
+| rules       | List<Rule>          | List of rules                  |
+| totalCount  | integer             | Total number of rules          |
+| pageSize    | integer             | Number of rules per page       |
+| pageNumber  | integer             | Current page number            |
+
+#### Rule Object
+
+| Property    | Type   | Description                    |
+|-------------|--------|--------------------------------|
+| id          | string | Rule ID                        |
+| name        | string | Rule name                      |
+| description | string | Rule description               |
+| status      | string | Rule status                    |
+| createdAt   | string | Creation timestamp             |
+| updatedAt   | string | Last update timestamp          |
+
+## Error Handling
+
+The tasks handle various error scenarios:
+
+1. **API Authentication Errors**
+   - HTTP 401 responses
+   - Invalid API keys
+   - Solution: Verify your API key is correct and has proper permissions
+
+2. **Rule Execution Errors**
+   - Invalid rule IDs
+   - Rule execution failures
+   - Solution: Check the rule ID and ensure the rule is properly configured in Sifflet
+
+3. **Timeout Errors**
+   - Rule execution takes longer than the specified timeout
+   - Solution: Increase the timeout value or investigate why the rule is taking longer than expected
+
+4. **JSON Parsing Errors**
+   - Invalid response format from Sifflet API
+   - Solution: Contact Sifflet support if this occurs
+
+## Best Practices
+
+1. **API Key Security**
+   - Always use Kestra secrets to store your Sifflet API key
+   - Never hardcode API keys in your workflows
+   - Rotate API keys regularly
+
+2. **Timeout Configuration**
+   - Set appropriate timeout values based on your rule complexity
+   - Consider using longer timeouts for complex rules
+   - Monitor execution times to optimize timeout settings
+
+3. **Error Handling**
+   - Implement proper error handling in your workflows
+   - Use Kestra's error handling features to manage failures
+   - Monitor failed executions and investigate root causes
+
+## Development
+
+To build the plugin:
+
+```bash
+./gradlew build
+```
+
+## License
+
+Apache 2.0

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ java {
 }
 
 group = "io.kestra.plugin"
-description = 'Plugin template for Kestra'
+description = 'Sifflet plugin for Kestra'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = "UTF-8"
@@ -51,6 +51,10 @@ dependencies {
     annotationProcessor group: "io.kestra", name: "processor", version: kestraVersion
     compileOnly group: "io.kestra", name: "core", version: kestraVersion
     compileOnly group: "io.kestra", name: "script", version: kestraVersion
+
+    // jackson for JSON parsing
+    implementation "com.fasterxml.jackson.core:jackson-databind"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
 }
 
 
@@ -98,6 +102,9 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-engine"
     testImplementation "org.hamcrest:hamcrest"
     testImplementation "org.hamcrest:hamcrest-library"
+    
+    // MockWebServer for testing HTTP calls
+    testImplementation "com.squareup.okhttp3:mockwebserver:4.12.0"
 }
 
 /**********************************************************************************************************************\
@@ -157,9 +164,9 @@ jar {
     manifest {
         attributes(
                 "X-Kestra-Name": project.name,
-                "X-Kestra-Title": "Template",
-                "X-Kestra-Group": project.group + ".templates",
-                "X-Kestra-Description": project.description,
+                "X-Kestra-Title": "Sifflet",
+                "X-Kestra-Group": project.group + ".sifflet",
+                "X-Kestra-Description": "Sifflet plugin for Kestra",
                 "X-Kestra-Version": project.version
         )
     }

--- a/src/main/java/io/kestra/plugin/sifflet/tasks/ListRules.java
+++ b/src/main/java/io/kestra/plugin/sifflet/tasks/ListRules.java
@@ -1,0 +1,161 @@
+package io.kestra.plugin.sifflet.tasks;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "List Sifflet rules",
+    description = "Retrieve a list of rules from Sifflet."
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "List Sifflet rules",
+            code = {
+                """
+                id: list-sifflet-rules
+                type: io.kestra.plugin.sifflet.tasks.ListRules
+                url: https://api.siffletdata.com
+                apiKey: "{{ secret('SIFFLET_API_KEY') }}"
+                """
+            }
+        )
+    }
+)
+public class ListRules extends Task implements RunnableTask<ListRules.Output> {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Schema(
+        title = "Sifflet API URL",
+        description = "The base URL for the Sifflet API"
+    )
+    @PluginProperty(dynamic = true)
+    private String url;
+
+    @Schema(
+        title = "API Key",
+        description = "The API key for authentication with Sifflet"
+    )
+    @PluginProperty(dynamic = true, sensitive = true)
+    private String apiKey;
+
+    @Schema(
+        title = "Page Size",
+        description = "Number of rules to return per page"
+    )
+    @PluginProperty(dynamic = true)
+    @Builder.Default
+    private Integer pageSize = 100;
+
+    @Schema(
+        title = "Page Number",
+        description = "Page number to retrieve"
+    )
+    @PluginProperty(dynamic = true)
+    @Builder.Default
+    private Integer pageNumber = 1;
+
+    @Override
+    public ListRules.Output run(RunContext runContext) throws Exception {
+        String resolvedUrl = runContext.render(url);
+        String resolvedApiKey = runContext.render(apiKey);
+
+        HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(30))
+            .build();
+
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(resolvedUrl + "/api/v1/rules?pageSize=" + pageSize + "&pageNumber=" + pageNumber))
+            .header("Authorization", "Bearer " + resolvedApiKey)
+            .header("Content-Type", "application/json")
+            .GET()
+            .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        
+        if (response.statusCode() != 200) {
+            throw new Exception("Failed to list rules: " + response.body());
+        }
+
+        try {
+            RulesResponse rulesResponse = MAPPER.readValue(response.body(), RulesResponse.class);
+            return Output.builder()
+                .rules(rulesResponse.rules)
+                .totalCount(rulesResponse.totalCount)
+                .pageSize(rulesResponse.pageSize)
+                .pageNumber(rulesResponse.pageNumber)
+                .build();
+        } catch (Exception e) {
+            throw new Exception("Failed to parse rules response: " + e.getMessage(), e);
+        }
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(
+            title = "Rules",
+            description = "List of rules"
+        )
+        private List<Rule> rules;
+
+        @Schema(
+            title = "Total Count",
+            description = "Total number of rules"
+        )
+        private Integer totalCount;
+
+        @Schema(
+            title = "Page Size",
+            description = "Number of rules per page"
+        )
+        private Integer pageSize;
+
+        @Schema(
+            title = "Page Number",
+            description = "Current page number"
+        )
+        private Integer pageNumber;
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Rule {
+        private String id;
+        private String name;
+        private String description;
+        private String status;
+        private String createdAt;
+        private String updatedAt;
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class RulesResponse {
+        private List<Rule> rules;
+        private Integer totalCount;
+        private Integer pageSize;
+        private Integer pageNumber;
+    }
+} 

--- a/src/main/java/io/kestra/plugin/sifflet/tasks/ListRules.java
+++ b/src/main/java/io/kestra/plugin/sifflet/tasks/ListRules.java
@@ -77,7 +77,7 @@ public class ListRules extends Task implements RunnableTask<ListRules.Output> {
     private Integer pageNumber = 1;
 
     @Override
-    public ListRules.Output run(RunContext runContext) {
+    public ListRules.Output run(RunContext runContext) throws Exception {
         String resolvedUrl = runContext.render(url);
         String resolvedApiKey = runContext.render(apiKey);
         Integer resolvedPageSize = pageSize != null ? pageSize : 100;

--- a/src/main/java/io/kestra/plugin/sifflet/tasks/ListRules.java
+++ b/src/main/java/io/kestra/plugin/sifflet/tasks/ListRules.java
@@ -57,7 +57,7 @@ public class ListRules extends Task implements RunnableTask<ListRules.Output> {
         title = "API Key",
         description = "The API key for authentication with Sifflet"
     )
-    @PluginProperty(dynamic = true, sensitive = true)
+    @PluginProperty(dynamic = true)
     private String apiKey;
 
     @Schema(

--- a/src/main/java/io/kestra/plugin/sifflet/tasks/RunRule.java
+++ b/src/main/java/io/kestra/plugin/sifflet/tasks/RunRule.java
@@ -166,6 +166,7 @@ public class RunRule extends Task implements RunnableTask<RunRule.Output> {
         if (pollingException != null) {
             throw new RuntimeException("Polling failed: " + pollingException.getMessage(), pollingException);
         }
+        runContext.metric(Counter.of("rule.status", 1, "status", status));
         return Output.builder()
             .executionId(executionId)
             .status(status)

--- a/src/main/java/io/kestra/plugin/sifflet/tasks/RunRule.java
+++ b/src/main/java/io/kestra/plugin/sifflet/tasks/RunRule.java
@@ -1,0 +1,194 @@
+package io.kestra.plugin.sifflet.tasks;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.executions.metrics.Counter;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Run a Sifflet rule",
+    description = "Execute a rule in Sifflet and wait for its completion."
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Run a Sifflet rule",
+            code = {
+                """
+                id: run-sifflet-rule
+                type: io.kestra.plugin.sifflet.tasks.RunRule
+                url: https://api.siffletdata.com
+                apiKey: "{{ secret('SIFFLET_API_KEY') }}"
+                ruleId: "rule-123"
+                """
+            }
+        )
+    }
+)
+public class RunRule extends Task implements RunnableTask<RunRule.Output> {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Schema(
+        title = "Sifflet API URL",
+        description = "The base URL for the Sifflet API"
+    )
+    @PluginProperty(dynamic = true)
+    private String url;
+
+    @Schema(
+        title = "API Key",
+        description = "The API key for authentication with Sifflet"
+    )
+    @PluginProperty(dynamic = true, sensitive = true)
+    private String apiKey;
+
+    @Schema(
+        title = "Rule ID",
+        description = "The ID of the rule to run"
+    )
+    @PluginProperty(dynamic = true)
+    private String ruleId;
+
+    @Schema(
+        title = "Polling Interval",
+        description = "The interval in seconds between status checks"
+    )
+    @PluginProperty(dynamic = true)
+    @Builder.Default
+    private Integer pollingInterval = 5;
+
+    @Schema(
+        title = "Timeout",
+        description = "The maximum time in seconds to wait for the rule to complete"
+    )
+    @PluginProperty(dynamic = true)
+    @Builder.Default
+    private Integer timeout = 3600;
+
+    @Override
+    public RunRule.Output run(RunContext runContext) throws Exception {
+        String resolvedUrl = runContext.render(url);
+        String resolvedApiKey = runContext.render(apiKey);
+        String resolvedRuleId = runContext.render(ruleId);
+
+        HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(30))
+            .build();
+
+        // Start the rule execution
+        HttpRequest startRequest = HttpRequest.newBuilder()
+            .uri(URI.create(resolvedUrl + "/api/v1/rules/" + resolvedRuleId + "/run"))
+            .header("Authorization", "Bearer " + resolvedApiKey)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.noBody())
+            .build();
+
+        HttpResponse<String> startResponse = client.send(startRequest, HttpResponse.BodyHandlers.ofString());
+        
+        if (startResponse.statusCode() != 200) {
+            throw new Exception("Failed to start rule execution: " + startResponse.body());
+        }
+
+        // Parse the execution ID from the response
+        ExecutionResponse executionResponse;
+        try {
+            executionResponse = MAPPER.readValue(startResponse.body(), ExecutionResponse.class);
+        } catch (Exception e) {
+            throw new Exception("Failed to parse response: " + e.getMessage(), e);
+        }
+        String executionId = executionResponse.executionId;
+
+        // Poll for completion
+        boolean completed = false;
+        String status = "";
+        long startTime = System.currentTimeMillis();
+        long timeoutMillis = timeout * 1000L;
+
+        while (!completed) {
+            if (System.currentTimeMillis() - startTime > timeoutMillis) {
+                throw new Exception("Rule execution timed out after " + timeout + " seconds");
+            }
+
+            HttpRequest statusRequest = HttpRequest.newBuilder()
+                .uri(URI.create(resolvedUrl + "/api/v1/executions/" + executionId))
+                .header("Authorization", "Bearer " + resolvedApiKey)
+                .GET()
+                .build();
+
+            HttpResponse<String> statusResponse = client.send(statusRequest, HttpResponse.BodyHandlers.ofString());
+            
+            if (statusResponse.statusCode() != 200) {
+                throw new Exception("Failed to get execution status: " + statusResponse.body());
+            }
+
+            ExecutionStatus executionStatus;
+            try {
+                executionStatus = MAPPER.readValue(statusResponse.body(), ExecutionStatus.class);
+            } catch (Exception e) {
+                throw new Exception("Failed to parse status response: " + e.getMessage(), e);
+            }
+            status = executionStatus.status;
+            
+            if (status.equals("COMPLETED") || status.equals("FAILED")) {
+                completed = true;
+            } else {
+                Thread.sleep(pollingInterval * 1000L);
+            }
+        }
+
+        // Record metrics
+        runContext.metric(Counter.of("rule.status", 1, "status", status));
+
+        return Output.builder()
+            .executionId(executionId)
+            .status(status)
+            .build();
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(
+            title = "Execution ID",
+            description = "The ID of the rule execution"
+        )
+        private String executionId;
+
+        @Schema(
+            title = "Status",
+            description = "The final status of the rule execution"
+        )
+        private String status;
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class ExecutionResponse {
+        private String executionId;
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class ExecutionStatus {
+        private String status;
+    }
+} 

--- a/src/main/java/io/kestra/plugin/sifflet/tasks/RunRule.java
+++ b/src/main/java/io/kestra/plugin/sifflet/tasks/RunRule.java
@@ -82,7 +82,7 @@ public class RunRule extends Task implements RunnableTask<RunRule.Output> {
     )
     @PluginProperty(dynamic = true)
     @Builder.Default
-    private Integer timeout = 3600;
+    private Integer ruleTimeout = 3600;
 
     @Override
     public RunRule.Output run(RunContext runContext) throws Exception {
@@ -124,13 +124,13 @@ public class RunRule extends Task implements RunnableTask<RunRule.Output> {
         }
 
         long startTime = System.currentTimeMillis();
-        long timeoutMillis = timeout * 1000L;
+        long timeoutMillis = ruleTimeout * 1000L;
         boolean completed = false;
         String status = null;
         Exception pollingException = null;
         while (!completed) {
             if (System.currentTimeMillis() - startTime > timeoutMillis) {
-                throw new RuntimeException("Rule execution timed out after " + timeout + " seconds");
+                throw new RuntimeException("Rule execution timed out after " + ruleTimeout + " seconds");
             }
             try {
                 Thread.sleep(pollingInterval * 1000L);

--- a/src/main/java/io/kestra/plugin/sifflet/tasks/RunRule.java
+++ b/src/main/java/io/kestra/plugin/sifflet/tasks/RunRule.java
@@ -200,4 +200,3 @@ public class RunRule extends Task implements RunnableTask<RunRule.Output> {
         private String status;
     }
 } 
-} 

--- a/src/main/java/io/kestra/plugin/sifflet/tasks/RunRule.java
+++ b/src/main/java/io/kestra/plugin/sifflet/tasks/RunRule.java
@@ -58,7 +58,7 @@ public class RunRule extends Task implements RunnableTask<RunRule.Output> {
         title = "API Key",
         description = "The API key for authentication with Sifflet"
     )
-    @PluginProperty(dynamic = true, sensitive = true)
+    @PluginProperty(dynamic = true)
     private String apiKey;
 
     @Schema(

--- a/src/test/java/io/kestra/plugin/sifflet/tasks/ListRulesTest.java
+++ b/src/test/java/io/kestra/plugin/sifflet/tasks/ListRulesTest.java
@@ -1,0 +1,124 @@
+package io.kestra.plugin.sifflet.tasks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.IdUtils;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@MicronautTest
+class ListRulesTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    private MockWebServer mockWebServer;
+    private ObjectMapper objectMapper;
+    private String baseUrl;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        baseUrl = "http://localhost:" + mockWebServer.getPort();
+        objectMapper = new ObjectMapper();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void testListRules() throws Exception {
+        // Mock successful response
+        mockWebServer.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setBody(objectMapper.writeValueAsString(Map.of(
+                "rules", List.of(Map.of(
+                    "id", "rule-1",
+                    "name", "Test Rule",
+                    "description", "Test Description",
+                    "status", "ACTIVE",
+                    "createdAt", "2024-02-26T10:00:00Z",
+                    "updatedAt", "2024-02-26T10:00:00Z"
+                )),
+                "totalCount", 1,
+                "pageSize", 100,
+                "pageNumber", 1
+            ))));
+
+        ListRules task = ListRules.builder()
+            .id(IdUtils.create())
+            .type(ListRules.class.getName())
+            .url(baseUrl)
+            .apiKey("test-api-key")
+            .build();
+
+        RunContext runContext = runContextFactory.of();
+        ListRules.Output output = task.run(runContext);
+
+        assertThat(output, is(notNullValue()));
+        assertThat(output.getRules(), hasSize(1));
+        assertThat(output.getTotalCount(), is(1));
+        assertThat(output.getPageSize(), is(100));
+        assertThat(output.getPageNumber(), is(1));
+
+        ListRules.Rule rule = output.getRules().get(0);
+        assertThat(rule.getId(), is("rule-1"));
+        assertThat(rule.getName(), is("Test Rule"));
+        assertThat(rule.getDescription(), is("Test Description"));
+        assertThat(rule.getStatus(), is("ACTIVE"));
+    }
+
+    @Test
+    void testApiError() {
+        // Mock API error
+        mockWebServer.enqueue(new MockResponse()
+            .setResponseCode(401)
+            .setBody("Unauthorized"));
+
+        ListRules task = ListRules.builder()
+            .id(IdUtils.create())
+            .type(ListRules.class.getName())
+            .url(baseUrl)
+            .apiKey("invalid-api-key")
+            .build();
+
+        RunContext runContext = runContextFactory.of();
+        Exception exception = assertThrows(Exception.class, () -> task.run(runContext));
+        assertThat(exception.getMessage(), containsString("Failed to list rules"));
+    }
+
+    @Test
+    void testInvalidJsonResponse() {
+        // Mock invalid JSON response
+        mockWebServer.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setBody("invalid json"));
+
+        ListRules task = ListRules.builder()
+            .id(IdUtils.create())
+            .type(ListRules.class.getName())
+            .url(baseUrl)
+            .apiKey("test-api-key")
+            .build();
+
+        RunContext runContext = runContextFactory.of();
+        Exception exception = assertThrows(Exception.class, () -> task.run(runContext));
+        assertThat(exception.getMessage(), containsString("Failed to parse rules response"));
+    }
+} 

--- a/src/test/java/io/kestra/plugin/sifflet/tasks/RunRuleTest.java
+++ b/src/test/java/io/kestra/plugin/sifflet/tasks/RunRuleTest.java
@@ -60,7 +60,7 @@ class RunRuleTest {
             .apiKey("test-api-key")
             .ruleId("test-rule-id")
             .pollingInterval(1)
-            .timeout(10)
+            .ruleTimeout(10)
             .build();
 
         RunContext runContext = runContextFactory.of();
@@ -90,7 +90,7 @@ class RunRuleTest {
             .apiKey("test-api-key")
             .ruleId("test-rule-id")
             .pollingInterval(1)
-            .timeout(10)
+            .ruleTimeout(10)
             .build();
 
         RunContext runContext = runContextFactory.of();
@@ -115,7 +115,7 @@ class RunRuleTest {
             .apiKey("invalid-api-key")
             .ruleId("test-rule-id")
             .pollingInterval(1)
-            .timeout(10)
+            .ruleTimeout(10)
             .build();
 
         RunContext runContext = runContextFactory.of();
@@ -144,7 +144,7 @@ class RunRuleTest {
             .apiKey("test-api-key")
             .ruleId("test-rule-id")
             .pollingInterval(1)
-            .timeout(1) // Set a very short timeout
+            .ruleTimeout(1) // Set a very short timeout
             .build();
 
         RunContext runContext = runContextFactory.of();
@@ -170,7 +170,7 @@ class RunRuleTest {
             .apiKey("test-api-key")
             .ruleId("test-rule-id")
             .pollingInterval(1)
-            .timeout(10)
+            .ruleTimeout(10)
             .build();
 
         RunContext runContext = runContextFactory.of();
@@ -197,7 +197,7 @@ class RunRuleTest {
             .apiKey("test-api-key")
             .ruleId("test-rule-id")
             .pollingInterval(1)
-            .timeout(10)
+            .ruleTimeout(10)
             .build();
 
         RunContext runContext = runContextFactory.of();
@@ -223,7 +223,7 @@ class RunRuleTest {
             .apiKey("test-api-key")
             .ruleId("test-rule-id")
             .pollingInterval(1)
-            .timeout(10)
+            .ruleTimeout(10)
             .build();
 
         RunContext runContext = runContextFactory.of();

--- a/src/test/java/io/kestra/plugin/sifflet/tasks/RunRuleTest.java
+++ b/src/test/java/io/kestra/plugin/sifflet/tasks/RunRuleTest.java
@@ -1,0 +1,174 @@
+package io.kestra.plugin.sifflet.tasks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.IdUtils;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@MicronautTest
+class RunRuleTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    private MockWebServer mockWebServer;
+    private ObjectMapper objectMapper;
+    private String baseUrl;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        baseUrl = "http://localhost:" + mockWebServer.getPort();
+        objectMapper = new ObjectMapper();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void testSuccessfulRuleExecution() throws Exception {
+        // Mock successful rule start
+        mockWebServer.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setBody(objectMapper.writeValueAsString(Map.of("executionId", "test-execution-123"))));
+
+        // Mock successful status check
+        mockWebServer.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setBody(objectMapper.writeValueAsString(Map.of("status", "COMPLETED"))));
+
+        RunRule task = RunRule.builder()
+            .id(IdUtils.create())
+            .type(RunRule.class.getName())
+            .url(baseUrl)
+            .apiKey("test-api-key")
+            .ruleId("test-rule-id")
+            .pollingInterval(1)
+            .timeout(10)
+            .build();
+
+        RunContext runContext = runContextFactory.of();
+        RunRule.Output output = task.run(runContext);
+
+        assertThat(output, is(notNullValue()));
+        assertThat(output.getExecutionId(), is("test-execution-123"));
+        assertThat(output.getStatus(), is("COMPLETED"));
+    }
+
+    @Test
+    void testFailedRuleExecution() throws Exception {
+        // Mock successful rule start
+        mockWebServer.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setBody(objectMapper.writeValueAsString(Map.of("executionId", "test-execution-123"))));
+
+        // Mock failed status check
+        mockWebServer.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setBody(objectMapper.writeValueAsString(Map.of("status", "FAILED"))));
+
+        RunRule task = RunRule.builder()
+            .id(IdUtils.create())
+            .type(RunRule.class.getName())
+            .url(baseUrl)
+            .apiKey("test-api-key")
+            .ruleId("test-rule-id")
+            .pollingInterval(1)
+            .timeout(10)
+            .build();
+
+        RunContext runContext = runContextFactory.of();
+        RunRule.Output output = task.run(runContext);
+
+        assertThat(output, is(notNullValue()));
+        assertThat(output.getExecutionId(), is("test-execution-123"));
+        assertThat(output.getStatus(), is("FAILED"));
+    }
+
+    @Test
+    void testApiError() {
+        // Mock API error
+        mockWebServer.enqueue(new MockResponse()
+            .setResponseCode(401)
+            .setBody("Unauthorized"));
+
+        RunRule task = RunRule.builder()
+            .id(IdUtils.create())
+            .type(RunRule.class.getName())
+            .url(baseUrl)
+            .apiKey("invalid-api-key")
+            .ruleId("test-rule-id")
+            .pollingInterval(1)
+            .timeout(10)
+            .build();
+
+        RunContext runContext = runContextFactory.of();
+        Exception exception = assertThrows(Exception.class, () -> task.run(runContext));
+        assertThat(exception.getMessage(), containsString("Failed to start rule execution"));
+    }
+
+    @Test
+    void testTimeout() throws Exception {
+        // Mock successful rule start
+        mockWebServer.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setBody(objectMapper.writeValueAsString(Map.of("executionId", "test-execution-123"))));
+
+        // Mock running status
+        mockWebServer.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setBody(objectMapper.writeValueAsString(Map.of("status", "RUNNING"))));
+
+        RunRule task = RunRule.builder()
+            .id(IdUtils.create())
+            .type(RunRule.class.getName())
+            .url(baseUrl)
+            .apiKey("test-api-key")
+            .ruleId("test-rule-id")
+            .pollingInterval(1)
+            .timeout(1) // Set a very short timeout
+            .build();
+
+        RunContext runContext = runContextFactory.of();
+        Exception exception = assertThrows(Exception.class, () -> task.run(runContext));
+        assertThat(exception.getMessage(), containsString("Rule execution timed out"));
+    }
+
+    @Test
+    void testInvalidJsonResponse() {
+        // Mock invalid JSON response
+        mockWebServer.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setBody("invalid json"));
+
+        RunRule task = RunRule.builder()
+            .id(IdUtils.create())
+            .type(RunRule.class.getName())
+            .url(baseUrl)
+            .apiKey("test-api-key")
+            .ruleId("test-rule-id")
+            .pollingInterval(1)
+            .timeout(10)
+            .build();
+
+        RunContext runContext = runContextFactory.of();
+        Exception exception = assertThrows(Exception.class, () -> task.run(runContext));
+        assertThat(exception.getMessage(), containsString("Failed to parse response"));
+    }
+} 


### PR DESCRIPTION
# Add Sifflet Plugin with RunRule and ListRules Tasks

## Description
This PR adds a new Sifflet plugin for Kestra with two main tasks:
1. `RunRule`: Executes Sifflet rules and monitors their execution status
2. `ListRules`: Lists available rules from Sifflet with pagination support

## Changes
- Added RunRule task implementation with proper error handling and timeouts
- Added ListRules task for retrieving rule information
- Added comprehensive test coverage using MockWebServer
- Added GitHub Actions workflow for CI/CD
- Added detailed documentation in README.md
- Added contribution guidelines and changelog

## Testing
- All unit tests pass
- Tested with MockWebServer for API responses
- Tested error handling scenarios

## Documentation
- Added installation instructions
- Added usage examples
- Added property descriptions
- Added error handling guide
- Added best practices section

## Related Issues
Closes #7594

## Checklist
- [x] Code follows the project's coding style
- [x] Tests have been added/updated
- [x] Documentation has been updated
- [x] CI/CD pipeline is configured
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added a Sifflet plugin for Kestra with tasks to run Sifflet rules and list available rules, including error handling, tests, and documentation.

- **New Features**
  - Added `RunRule` task to execute Sifflet rules and monitor their status.
  - Added `ListRules` task to fetch rules with pagination support.

<!-- End of auto-generated description by mrge. -->

